### PR TITLE
Add changes to the documentation to allow for go install command

### DIFF
--- a/docs/authenticate/local/30-password-management.md
+++ b/docs/authenticate/local/30-password-management.md
@@ -10,6 +10,11 @@ First, download `bcrypt-cli`:
 go get -u github.com/bitnami/bcrypt-cli
 ```
 
+If you are using a newer version of Go use the following command to download `bcrypt-cli`:
+```bash
+go install github.com/bitnami/bcrypt-cli@v1.0.2
+```
+
 Then, use it to generate a new password:
 
 ```bash


### PR DESCRIPTION
Recommend adding the following changes for go install instructions to the local user password management page: 
If you are using a newer version of Go use the following command to download `bcrypt-cli`:
```bash
go install github.com/bitnami/bcrypt-cli@v1.0.2
```