### PR TITLE
Discord OAuth2 idp  documentation extension for Guild Roles

### DIFF
--- a/assets/conf/oauth/discord/Caddyfile
+++ b/assets/conf/oauth/discord/Caddyfile
@@ -1,0 +1,57 @@
+{
+	http_port 8080
+	https_port 8443
+	# debug
+
+	order authenticate before respond
+	order authorize before basicauth
+
+        security {
+                oauth identity provider discord {
+                        realm discord
+                        driver discord
+                        client_id {$CLIENT_ID}
+                        client_secret {$CLIENT_SECRET}
+                        scopes identify guilds guilds.members.read
+                        user_group_filters {$GUILD_ID}
+                }
+                authentication portal discordportal {
+                        crypto default token lifetime 3600
+                        crypto key sign-verify {env.JWT_SHARED_KEY}
+                        enable identity provider discord
+                        cookie domain myfiosgateway.com
+
+                        transform user {
+                                match role discord.com/{$GUILD_ID}/role/{$ADMIN_ROLE_ID}
+                                action add role authp/admin
+                        }
+                        transform user {
+                                match role discord.com/{$MYGUILDID}/members
+                                action add role authp/user
+                        }
+                }
+                authorization policy mypolicy {
+                        set auth url https://myfiosgateway.com/auth/
+                        crypto key verify {env.JWT_SHARED_KEY}
+                        allow roles authp/admin authp/user
+                        validate bearer header
+                        inject headers with claims
+                }
+
+        }
+}
+
+(tls_config) {
+	tls {$HOME}/.local/caddy/server.crt {$HOME}/.local/caddy/server.key
+}
+
+https://myfiosgateway.com {
+        import tls_config
+        route /auth/* {
+                authenticate with discordportal
+        }
+        route {
+                authorize with mypolicy
+                respond "Hello World"
+        }
+}

--- a/docs/authenticate/oauth/81-backend-oauth2-0013-discord.md
+++ b/docs/authenticate/oauth/81-backend-oauth2-0013-discord.md
@@ -27,7 +27,7 @@ oauth identity provider discord {
   driver discord
   client_id {$CLIENT_ID}
   client_secret {$CLIENT_SECRET}
-  scopes identify email guilds guilds.members.read # Note: `email`, `guilds`, and `guilds.members.read` are optional, see notes below
+  scopes identify email guilds guilds.members.read # Optional, `email`, `guilds`, and `guilds.members.read` are optional, see notes below
   user_group_filters {$DISCORD_GUILD_ID} {$OTHER_GUILD_ID} # Optional, effective only if scope guilds is specified
 }
 ```
@@ -84,8 +84,8 @@ transform user {
 
 To find the Role IDs for a server:
 1. Enable developer mode by going to Settings->\[App Settings\]->Advanced->Enable Developer Mode
-2. Go to the Server Settings for the each guild you want to filter by
-3. Go to Roles, and right click on the Role row you want, you should see an option "Copy Role ID"
+2. Go to the Server Settings for the guild you want to filter by
+3. Go to Roles, and right click on the Role in the list of roles that you want, you should see an option "Copy Role ID"
 
 ### Filtering by guild role
 
@@ -103,7 +103,7 @@ transform user { # Give a role `authp/rolename` for the specified Role ID in a s
     action add role authp/rolename
 }
 
-transform user { # Give the role `authp/user` for all members of the guild
+transform user { # Give the role `authp/user` for all members of the guild regardless of their role in the guild
     match role discord.com/{$DISCORD_GUILD_ID}/members
     action add role authp/user
 }

--- a/docs/authenticate/oauth/81-backend-oauth2-0013-discord.md
+++ b/docs/authenticate/oauth/81-backend-oauth2-0013-discord.md
@@ -4,6 +4,8 @@ Discord OAuth2 integration allows you to use discord as an identity provider.
 
 It also allows you to add roles to the users based on which "discord servers" they are members of.
 
+The following [`Caddyfile`](https://github.com/authp/authp.github.io/blob/main/assets/conf/oauth/discord/Caddyfile) allows Discord-based authentication
+
 ### Registering a discord application
 
 In order to use this plugin with caddy-security you'll need a to register an application in the [Discord Developer Portal](https://discord.com/developers/applications).
@@ -25,7 +27,7 @@ oauth identity provider discord {
   driver discord
   client_id {$CLIENT_ID}
   client_secret {$CLIENT_SECRET}
-  scopes identify email guilds # Optional, see notes below
+  scopes identify email guilds guilds.members.read # Note: `email`, `guilds`, and `guilds.members.read` are optional, see notes below
   user_group_filters {$DISCORD_GUILD_ID} {$OTHER_GUILD_ID} # Optional, effective only if scope guilds is specified
 }
 ```
@@ -52,7 +54,7 @@ To get a discord ID for a particular user using the discord desktop app:
 
 **Note**: "Guild" is the discord terminology for a "discord server"
 
-**Note**: In order to disciminate users based on which guild they belong to you have to enable the guild scope in the discord oauth configuratio above (`scopes identity guild`)
+**Note**: In order to discriminate users based on which guild they belong to you have to enable the `guilds` scope in the discord oauth configuration above (`scopes identify guilds`)
 
 After the user is authenticated another query is made to the discord api requesting a list of guild IDs the user is part of. By default the result is ignored, which means no new roles will be added to the user object based on guild membership.
 
@@ -75,6 +77,33 @@ transform user {
 }
 
 transform user {
+    match role discord.com/{$DISCORD_GUILD_ID}/members
+    action add role authp/user
+}
+```
+
+To find the Role IDs for a server:
+1. Enable developer mode by going to Settings->\[App Settings\]->Advanced->Enable Developer Mode
+2. Go to the Server Settings for the each guild you want to filter by
+3. Go to Roles, and right click on the Role row you want, you should see an option "Copy Role ID"
+
+### Filtering by guild role
+
+**Note**: To enable discriminating users based on their role in a specific guild you must enable both the `guilds` AND `guilds.members.read` scopes. (`scopes identify guilds guilds.members.read`) [Read more here](https://discord.com/developers/docs/resources/user#get-current-user-guild-member)
+
+Filtering by role in a guild can be combined with `Filtering by guild` above. Members of a guild will still receive the `discord.com/{$DISCORD_GUILD_ID}/members` and `discord.com/{$DISCORD_GUILD_ID}/admins` roles above.
+
+Users will also receive `discord.com/{$DISCORD_GUILD_ID}/role/{$DISCORD_ROLE_ID}` for each role the user has in each of the guilds specified in `user_group_filters`
+
+Just as in the section above `Filter by guild`, after the user authenticates another query is made to the discord api to fetch their guild IDs, this list of guild IDs is filtered by `user_group_filters`. If the `guilds.members.read` scope is specified then for each specified guild, a query to fetch the user's member data will be made. Only the role ids from this response are saved and they can be used as demonstrated below.
+
+```caddyfile
+transform user { # Give a role `authp/rolename` for the specified Role ID in a specific guild
+    match role discord.com/{$DISCORD_GUILD_ID}/role/{$DISCORD_ROLE_ID}
+    action add role authp/rolename
+}
+
+transform user { # Give the role `authp/user` for all members of the guild
     match role discord.com/{$DISCORD_GUILD_ID}/members
     action add role authp/user
 }


### PR DESCRIPTION
Summary:
- This documentation is supporting the addition of Guild Role based authentication for Caddy-Security
- For each Discord Guild in user_group_filters an additional API call will be made to `https://discord.com/api/v10/users/@me/guilds/{guild.id}/member`. This API call will contain the Role IDs for a user in a given Guild
- Guild Roles can be used in the `transform user` block of the Caddyfile as described in the docs added. The new roles will be in this format `discord.com/{$DISCORD_GUILD_ID}/role/{$DISCORD_ROLE_ID}`
- Existing roles will continue to be added undisturbed (`dicord.com/{$GUILD_ID}/members`, `dicord.com/{$GUILD_ID}/admins`)
- Replaced a func that is fails on 32-bit systems related to assignment of the role `dicord.com/{$GUILD_ID}/admins`
- Minor typos fixes

Code PR - https://github.com/greenpau/go-authcrunch/pull/50