### PR TITLE
Update getting-started: GitHub search link broken

### DIFF
--- a/docs/authenticate/getting-started.md
+++ b/docs/authenticate/getting-started.md
@@ -11,5 +11,5 @@ the [conf](https://github.com/greenpau/caddy-auth-docs/blob/main/assets/conf/)
 
 Additionally, please see issues tagged [config example](https://github.com/greenpau/caddy-security/issues?q=label%3A%22config+example%22+).
 
-Further, [search](https://github.com/search?l=Dockerfile&q=greenpau%2Fcaddy-security&type=Code)
+Further, [search](https://github.com/search?q=greenpau%2Fcaddy-security+lang%3ADockerfile+&type=code)
 Github for the Dockerfile files referencing `caddy-security`. Then, see how others use it.


### PR DESCRIPTION
GitHub seems to have changed their search page URL parser and it doesn't accept `l` param any longer. `greenpau/caddy-security lang:Dockerfile ` seems to work though!