### PR TITLE
Fix Discord oauth2 example Caddyfile to use correct auth URL

### DIFF
--- a/assets/conf/oauth/discord/Caddyfile
+++ b/assets/conf/oauth/discord/Caddyfile
@@ -31,7 +31,7 @@
 			}
 		}
 		authorization policy mypolicy {
-			set auth url https://myfiosgateway.com/auth/
+			set auth url https://myfiosgateway.com/auth/oauth2/discord
 			crypto key verify {env.JWT_SHARED_KEY}
 			allow roles authp/admin authp/user
 			validate bearer header


### PR DESCRIPTION
Took a little while to figure out what was going on here. Hoping to save the next person to use this example the same trouble.