### PR TITLE
add links to SAML plugins documentation

### DIFF
--- a/docs/authenticate/saml/10-saml.md
+++ b/docs/authenticate/saml/10-saml.md
@@ -2,7 +2,8 @@
 
 The plugin supports the following SAML identity providers (IdP):
 
-* Azure Active Directory (Office 365) Applications
+* [Azure Active Directory](20-azure.md) (Office 365) Applications.
+* [JumpCloud](30-jumpcloud.md).
 
 If you would like to see the support for the following identity providers,
 please reach out:

--- a/docs/authenticate/saml/30-jumpcloud.md
+++ b/docs/authenticate/saml/30-jumpcloud.md
@@ -1,4 +1,4 @@
-# Jumpcloud SAML Integration
+# JumpCloud SAML Integration
 
 This [`Caddyfile`](https://github.com/greenpau/caddy-auth-docs/blob/main/assets/conf/saml/jumpcloud/Caddyfile)
 contains the configuration for the SAML integration.


### PR DESCRIPTION
Hello @greenpau.
While reading the docs, I noticed these two missing links.
Thanks.