### PR TITLE
docs: add portal and profile API endpoints

### DIFF
--- a/docs/authenticate/api/_category_.json
+++ b/docs/authenticate/api/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "API",
+  "position": 55
+}

--- a/docs/authenticate/api/portal.md
+++ b/docs/authenticate/api/portal.md
@@ -1,0 +1,44 @@
+# Portal JSON Endpoints
+
+These endpoints expose the portal’s core authentication data over JSON. Prefix
+them with your portal mount path (e.g., `/auth` → `/auth/json/login`).
+
+## `POST /json/login`
+
+Authenticate with JSON credentials and receive a session token.
+
+- **Body:** `{"username":"<user>","password":"<pass>","realm":"<realm>"}`  
+- **Success:** `200 OK` with `{"token":"<jwt>","token_name":"<cookie name>"}`
+- **Failure:** `401 Unauthorized` with error JSON.
+
+Example:
+
+```bash
+curl -X POST https://auth.example.com/json/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","password":"secret","realm":"local"}'
+```
+
+## `GET /json/whoami`
+
+Return the authenticated user claims.
+
+- **Query params (optional):**
+  - `probe=true` – include `authenticated` and `expires_in` seconds.
+  - `id_token=true` – include `id_token` cookie value when available.
+- **Success:** `200 OK` with user claim map.
+- **Failure:** `401 Unauthorized`.
+
+Example:
+
+```bash
+curl -H "Cookie: <portal-session-cookie>" \
+  "https://auth.example.com/json/whoami?probe=true"
+```
+
+## `GET /json/beacon`
+
+Lightweight health/identity check.
+
+- **Success:** `200 OK` body `OK` when the session is valid.
+- **Failure:** `401 Unauthorized`.

--- a/docs/authenticate/api/profile.md
+++ b/docs/authenticate/api/profile.md
@@ -1,0 +1,54 @@
+# Administrative API Endpoints
+
+Administrative API calls are **JWT-authenticated** and require the portal’s
+`api.admin` (or `api.profile`) configuration to be enabled. Paths are relative
+to the portal mount (e.g., `/auth/api/...`). All requests are JSON.
+
+## `POST /api/server/realms`
+- **Role:** `admin`
+- **Body:** `{"query":"<substring|all>"}` (optional)
+- **Response:** `200 OK` with `realms` array `{realm,name,kind}` and `count`.
+
+Example:
+```bash
+curl -X POST https://auth.example.com/api/server/realms \
+  -H "Content-Type: application/json" \
+  -d '{"query":"all"}' -H "Cookie: <portal-session>"
+```
+
+## `POST /api/server/users`
+- **Role:** `admin`
+- **Body:** `{"realm":"<realm>","query":"<filter>"}` (realm required)
+- **Response:** `200 OK` with `{count, users[], timestamp}` metadata list.
+
+## `POST /api/server/reload`
+- **Role:** `admin`
+- **Body:** `{"realm":"<realm>"}` (required)
+- **Response:** `200 OK` with `{status:"success|failure", timestamp}`.
+
+## `POST /api/server/info`
+- **Role:** `admin`
+- **Body:** `{"realm":"<realm>","query":"<metadata selector>"}` (realm required)
+- **Response:** `200 OK` with realm metadata and `timestamp`.
+
+## `GET /api/server/metadata`
+- **Role:** `admin`
+- **Response:** `200 OK` with AuthCrunch build/version info plus `timestamp`.
+
+## `POST /api/profile`
+- **Role:** `admin` or `user` (when `api.profile` enabled)
+- **Body:** `{"kind":"<operation>", ...}` where `kind` is one of:
+  - `fetch_debug`, `fetch_user_dashboard_data`, `fetch_user_info`
+  - `update_user_password`
+  - MFA operations: `fetch_user_multi_factor_authenticator(s)`, `add_user_app_multi_factor_authenticator`, `test_user_app_multi_factor_authenticator`, `delete_user_multi_factor_authenticator`, etc.
+  - API/SSH/GPG key operations: `fetch_user_api_keys`, `add_user_api_key`, `test_user_api_key`, `delete_user_api_key`, and analogous `*_ssh_key`, `*_gpg_key`
+  - U2F/WebAuthn operations: `fetch_user_u2f_reg_params`, `test_user_webauthn_token`, etc.
+- **Response:** `200 OK` on success with operation-specific payload; `400/403/501` on invalid kind, role, or unsupported backend.
+
+Example (fetch profile info):
+```bash
+curl -X POST https://auth.example.com/api/profile \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <portal-session>" \
+  -d '{"kind":"fetch_user_info"}'
+```


### PR DESCRIPTION
## Summary
- add dedicated API section under Authenticate docs
- document JSON portal endpoints (login, whoami, beacon)
- document administrative profile/server API endpoints with examples

## Rationale
- issue #459 requests documenting available API endpoints

## Changes
- docs/authenticate/api/_category_.json: new API subsection
- docs/authenticate/api/portal.md: portal JSON endpoints
- docs/authenticate/api/profile.md: admin/profile API endpoints

Fixes https://github.com/greenpau/caddy-security/issues/459