### PR TITLE
docs: add LDAP injection vulnerability blog post

### DIFF
--- a/blog/2026-03-10-ldap-injection-vulnerability/index.md
+++ b/blog/2026-03-10-ldap-injection-vulnerability/index.md
@@ -77,15 +77,6 @@ LDAP is everywhere:
 
 An LDAP injection lets you enumerate users, extract sensitive data, or take down the authentication system.
 
-## What to Do
-
-1. Merge PR #1 (has the tests)
-2. Apply the one-line fix at each of the three locations
-3. Release as a security patch
-4. Publish an advisory so users know to update
-
-The vulnerability is real but the fix is simple. One line, no breaking changes.
-
 ## References
 
 - CWE-90: https://cwe.mitre.org/data/definitions/90.html

--- a/blog/2026-03-10-ldap-injection-vulnerability/index.md
+++ b/blog/2026-03-10-ldap-injection-vulnerability/index.md
@@ -1,84 +1,20 @@
 ---
 slug: ldap-injection-vulnerability
-title: LDAP Injection Vulnerability in go-authcrunch
+title: How I found an LDAP Injection in go-authcrunch
 authors: [abhayclasher]
 tags: [security, ldap, vulnerability]
 ---
 
-I found a critical vulnerability in go-authcrunch's LDAP authenticator. Three functions don't escape user input before putting it into LDAP filter queries.
+I was looking through the LDAP authenticator code in `go-authcrunch` recently and noticed something that looked a bit off. I saw that the username is basically just dropped straight into the search filter string using a simple `ReplaceAll`.
 
 <!-- truncate -->
 
-## The Bug
+It's in three places: `findUser()`, `AuthenticateUser()`, and `searchGroups()`. If you've ever dealt with SQL injections, you know exactly where this is going.
 
-In `pkg/ids/ldap/authenticator.go`, lines 323, 430, and 559:
+I decided to test it. I tried using a wildcard `*` as my username. Instead of just looking for a user named "asterisk," the filter transformed into a "match everything" query. It worked—I could suddenly see every user in the directory.
 
-```go
-searchUserFilter := strings.ReplaceAll(sa.searchUserFilter, "%s", r.User.Username)
-```
+It gets worse if you get creative. You can use boolean logic (like `admin*))(&(uid=admin`) to start guessing usernames or even hammer the server with expensive queries until it slows to a crawl.
 
-The username goes straight into the filter with zero escaping. If I control the username, I control the LDAP filter.
+The fix is actually really simple, which is the good news. I just needed to wrap the input with `ldap.EscapeFilter()` before it hits the template. That one change turns the dangerous `*` into a safe `\2a` string that LDAP treats as text, not a command.
 
-## What You Can Do
-
-### User Enumeration
-
-Send username: `*`
-
-Normal filter: `(&(sAMAccountName=john)(objectclass=user))`  
-Result: Matches john
-
-Injected filter: `(&(sAMAccountName=*)(objectclass=user))`  
-Result: Matches EVERY user in the directory
-
-### Data Extraction
-
-Send username: `admin*))(&(uid=admin`
-
-This creates a malformed filter that uses boolean logic to check if admin exists, without actually seeing the results. You can enumerate the directory blindly.
-
-### Denial of Service
-
-Send a username that creates an expensive filter query. The LDAP server burns CPU trying to process it.
-
-## The Fix
-
-Replace the three vulnerable lines with:
-
-```go
-escapedUsername := ldap.EscapeFilter(r.User.Username)
-searchUserFilter := strings.ReplaceAll(sa.searchUserFilter, "%s", escapedUsername)
-```
-
-`ldap.EscapeFilter()` escapes the dangerous characters:
-- `*` → `\2a`
-- `(` → `\28`
-- `)` → `\29`
-
-Now if someone sends `*`, it matches only a user literally named `*`, not all users.
-
-## Testing
-
-I wrote two tests to verify the vulnerability and the fix:
-
-```
-TestLDAPInjection: Shows the wildcard bypass works
-TestEscapeFilter: Validates that escaping prevents it
-```
-
-Both pass. You can run `go test ./pkg/ids/ldap -v` to check.
-
-## Why This Matters
-
-LDAP is everywhere:
-- Active Directory (Windows auth)
-- OpenLDAP (Linux user management)
-- Enterprise SSO systems
-
-An LDAP injection lets you enumerate users, extract sensitive data, or take down the authentication system.
-
-## References
-
-- CWE-90: https://cwe.mitre.org/data/definitions/90.html
-- OWASP LDAP Injection: https://owasp.org/www-community/attacks/LDAP_Injection
-- go-ldap library: https://github.com/go-ldap/ldap
+I've pushed some tests to show how it works (and how it's fixed) in PR #1. If you're running LDAP auth, definitely make sure you're escaping your inputs!

--- a/blog/2026-03-10-ldap-injection-vulnerability/index.md
+++ b/blog/2026-03-10-ldap-injection-vulnerability/index.md
@@ -1,0 +1,93 @@
+---
+slug: ldap-injection-vulnerability
+title: LDAP Injection Vulnerability in go-authcrunch
+authors: [abhayclasher]
+tags: [security, ldap, vulnerability]
+---
+
+I found a critical vulnerability in go-authcrunch's LDAP authenticator. Three functions don't escape user input before putting it into LDAP filter queries.
+
+<!-- truncate -->
+
+## The Bug
+
+In `pkg/ids/ldap/authenticator.go`, lines 323, 430, and 559:
+
+```go
+searchUserFilter := strings.ReplaceAll(sa.searchUserFilter, "%s", r.User.Username)
+```
+
+The username goes straight into the filter with zero escaping. If I control the username, I control the LDAP filter.
+
+## What You Can Do
+
+### User Enumeration
+
+Send username: `*`
+
+Normal filter: `(&(sAMAccountName=john)(objectclass=user))`  
+Result: Matches john
+
+Injected filter: `(&(sAMAccountName=*)(objectclass=user))`  
+Result: Matches EVERY user in the directory
+
+### Data Extraction
+
+Send username: `admin*))(&(uid=admin`
+
+This creates a malformed filter that uses boolean logic to check if admin exists, without actually seeing the results. You can enumerate the directory blindly.
+
+### Denial of Service
+
+Send a username that creates an expensive filter query. The LDAP server burns CPU trying to process it.
+
+## The Fix
+
+Replace the three vulnerable lines with:
+
+```go
+escapedUsername := ldap.EscapeFilter(r.User.Username)
+searchUserFilter := strings.ReplaceAll(sa.searchUserFilter, "%s", escapedUsername)
+```
+
+`ldap.EscapeFilter()` escapes the dangerous characters:
+- `*` → `\2a`
+- `(` → `\28`
+- `)` → `\29`
+
+Now if someone sends `*`, it matches only a user literally named `*`, not all users.
+
+## Testing
+
+I wrote two tests to verify the vulnerability and the fix:
+
+```
+TestLDAPInjection: Shows the wildcard bypass works
+TestEscapeFilter: Validates that escaping prevents it
+```
+
+Both pass. You can run `go test ./pkg/ids/ldap -v` to check.
+
+## Why This Matters
+
+LDAP is everywhere:
+- Active Directory (Windows auth)
+- OpenLDAP (Linux user management)
+- Enterprise SSO systems
+
+An LDAP injection lets you enumerate users, extract sensitive data, or take down the authentication system.
+
+## What to Do
+
+1. Merge PR #1 (has the tests)
+2. Apply the one-line fix at each of the three locations
+3. Release as a security patch
+4. Publish an advisory so users know to update
+
+The vulnerability is real but the fix is simple. One line, no breaking changes.
+
+## References
+
+- CWE-90: https://cwe.mitre.org/data/definitions/90.html
+- OWASP LDAP Injection: https://owasp.org/www-community/attacks/LDAP_Injection
+- go-ldap library: https://github.com/go-ldap/ldap


### PR DESCRIPTION
Blog post explaining the LDAP injection vulnerability found in go-authcrunch, attack scenarios, and the fix.