### PR TITLE
docs: document MFA lockout behavior in sandbox checkpoint

### DIFF
--- a/docs/authenticate/local/60-sandbox.md
+++ b/docs/authenticate/local/60-sandbox.md
@@ -49,6 +49,13 @@ The MFA checkpoint behavior depends on what tokens the user has registered:
 
 Registration counts as passing the checkpoint.
 
+Failed MFA attempts are tracked on the user record across sandbox
+sessions. After 10 consecutive failures the MFA checkpoint is locked
+for 15 minutes. During lockout, MFA authentication is rejected without
+validating the code. The lockout expires automatically and the counter
+resets on successful MFA validation. Both authenticator app and hardware token failures
+contribute to the same counter.
+
 For adding MFA tokens outside the login flow, see
 [Multi-Factor Authentication](../11-mfa.md).
 


### PR DESCRIPTION
Add per-user MFA lockout description to the MFA checkpoint section of the sandbox page. Covers the 10-attempt threshold, 15-minute lockout duration, behavior during lockout, and auto-expiry.

Ref: greenpau/go-authcrunch#84, greenpau/go-authcrunch#85.