### PR TITLE
docs: document authentication challenge rules

### DIFF
--- a/docs/authenticate/13-authentication-challenges.md
+++ b/docs/authenticate/13-authentication-challenges.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 13
+---
+
 # Authentication Challenges
 
 Currently, when user attempts to login the users will be prompted for the password first. Then,
@@ -13,8 +17,87 @@ To summarize, there are two pathways to get authentication:
 1. password only
 2. password, then MFA (either app or hardware)
 
+Authentication challenge rules allow to change this default by specifying
+which challenge types a user must pass and in what order, with conditional
+fallbacks based on what the user has registered.
 
-## Future State
+## Challenge Types
+
+| Type | Description |
+|------|------------|
+| `password` | Authenticate with a password |
+| `totp` | Authenticate with an authenticator app passcode |
+| `u2f` | Authenticate with a hardware token (e.g. Yubico) or passkey |
+| `mfa` | Authenticate with any available MFA method (totp, u2f, or email) |
+
+**The `password` type is always considered available.** The other types
+require the user to have a matching token registered in the identity
+store.
+
+## Rule Syntax
+
+Each rule specifies one or more challenge types with an optional
+condition:
+
+```
+<type> [<type>...] [if <type> [and <type>...] not available]
+```
+
+Rules are evaluated in order. The first rule whose challenge types are
+available and whose conditions are met determines the checkpoint sequence.
+
+When multiple challenge types appear in a rule, the user must pass
+all of them. The `or` keyword relaxes the availability check: the rule
+matches if the user has at least one of the listed types registered,
+rather than requiring all of them.
+
+The `if ... not available` clause makes a rule apply only when the
+specified types are not registered for the user. If the user has any of
+the condition types registered, the rule is skipped.
+
+If no rules match, the default behavior applies (password, plus any
+detected MFA).
+
+## Configuring via authdbctl
+
+The `authdbctl` tool can set authentication challenge rules for a user:
+
+```bash
+authdbctl update user \
+  --username jsmith \
+  --email jsmith@localhost.localdomain \
+  --realm local \
+  --overwrite-auth-challenges "u2f" \
+  --overwrite-auth-challenges "password totp if u2f not available" \
+  --overwrite-auth-challenges "password if u2f and totp not available"
+```
+
+A successful response follows:
+
+```json
+{"auth_challenge_rules":["u2f","password totp if u2f not available","password if u2f and totp not available"],"status":"success","timestamp":"2026-03-25T10:30:00.000Z"}
+```
+
+The same operation is available via the Profile API. The request payload
+uses the `challenges` key:
+
+```json
+{
+  "challenges": [
+    "u2f",
+    "password totp if u2f not available",
+    "password if u2f and totp not available"
+  ]
+}
+```
+
+For details on installing `authdbctl`, see
+[Static Users](./local/50-static-users.md#password-generation).
+
+## Caddyfile Configuration
+
+Caddyfile support for authentication challenges is tracked in
+[#470](https://github.com/greenpau/caddy-security/issues/470).
 
 ### Via Transform User Directive
 
@@ -49,8 +132,57 @@ local identity store localdb {
 }
 ```
 
-### Via Profile API Endpoint
+## Evaluation Examples
 
-You should be able to configure the above with Profile API.
+The following table shows the checkpoint sequence for different users
+when the U2F-first ruleset is configured:
 
+| User has registered | Matching rule | Checkpoint sequence |
+|---------------------|--------------|---------------------|
+| Hardware token + authenticator app | `u2f` | u2f |
+| Hardware token only | `u2f` | u2f |
+| Authenticator app only | `password totp if u2f not available` | password, totp |
+| No MFA tokens | `password if u2f and totp not available` | password |
 
+When the user has both a hardware token and an authenticator app, the
+first rule matches because u2f is available. The authenticator app is
+not used.
+
+The following ruleset uses `or` to require any MFA method when at least
+one is registered:
+
+```
+u2f or totp
+password if u2f and totp not available
+```
+
+| User has registered | Matching rule | Checkpoint sequence |
+|---------------------|--------------|---------------------|
+| Hardware token + authenticator app | `u2f or totp` | u2f, totp |
+| Hardware token only | `u2f or totp` | u2f, totp |
+| Authenticator app only | `u2f or totp` | u2f, totp |
+| No MFA tokens | `password if u2f and totp not available` | password |
+
+When `or` is used, the rule matches if the user has at least one of the
+listed types registered. All listed types become checkpoints. If the
+user does not have a token for one of the types, they will be prompted
+to register one during login.
+
+## Editing the Identity Store Directly
+
+Authentication challenge rules are stored in the user record in
+`users.json`:
+
+```json
+{
+  "username": "jsmith",
+  "auth_challenge_rules": [
+    "u2f",
+    "password totp if u2f not available",
+    "password if u2f and totp not available"
+  ]
+}
+```
+
+For details on the identity store file format, see
+[Identity Store](./local/20-identity-store.md).

--- a/docs/authenticate/13-authentication-challenges.md
+++ b/docs/authenticate/13-authentication-challenges.md
@@ -29,6 +29,9 @@ fallbacks based on what the user has registered.
 | `totp` | Authenticate with an authenticator app passcode |
 | `u2f` | Authenticate with a hardware token (e.g. Yubico) or passkey |
 | `mfa` | Authenticate with any available MFA method (totp, u2f, or email) |
+| `email` | Authenticate with an email-based verification code * |
+
+\* Email challenge support is being added.
 
 **The `password` type is always considered available.** The other types
 require the user to have a matching token registered in the identity

--- a/docs/authenticate/42-user-transforms.md
+++ b/docs/authenticate/42-user-transforms.md
@@ -72,6 +72,9 @@ authenticated user's email is `webadmin@localdomain.local`:
   }
 ```
 
+For more advanced challenge configuration with conditional fallbacks,
+see [Authentication Challenges](./13-authentication-challenges.md).
+
 ## Deny Access
 
 The following transform blocks a user with email `anonymous@badactor.com`


### PR DESCRIPTION
Expands the authentication challenges page with challenge types, rule syntax, evaluation semantics, authdbctl configuration, Profile API payload, and identity store JSON format. Adds a cross-reference from the user transforms page.

Ref: greenpau/caddy-security#470, greenpau/caddy-security#338.