### PR TITLE
docs: add PKCE documentation

### DIFF
--- a/docs/authenticate/oauth/10-oauth2.md
+++ b/docs/authenticate/oauth/10-oauth2.md
@@ -42,6 +42,25 @@ References:
 * [Mozilla - OIDC in a nutshell](https://infosec.mozilla.org/guidelines/iam/openid_connect.html#oidc-in-a-nutshell)
 
 
+## PKCE
+
+PKCE ([RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)) adds an extra
+verification step during login to prevent authorization code interception. Some
+identity providers, e.g. Kanidm, require PKCE.
+
+The plugin enables PKCE by default for generic, okta, google, gitlab, azure,
+nextcloud, and cognito providers. Providers with non-standard OAuth flows
+(github, facebook, discord, linkedin) have PKCE disabled automatically.
+
+To disable PKCE for a specific provider:
+
+```
+oauth identity provider generic {
+    ...
+    disable pkce
+}
+```
+
 ## Adding Role Claims
 
 By default, all users authenticated with the plugin get `authp/guest`

--- a/docs/authenticate/oauth/82-backend-oauth2-endpoint.md
+++ b/docs/authenticate/oauth/82-backend-oauth2-endpoint.md
@@ -43,3 +43,13 @@ please reach out.
           ...
           enable logout
 ```
+
+## OAuth 2.0 PKCE
+
+PKCE is enabled by default. To disable it for a specific provider:
+
+```
+      oauth identity provider generic {
+          ...
+          disable pkce
+```


### PR DESCRIPTION
Ref: greenpau/caddy-security#334

Documents PKCE support added in greenpau/go-authcrunch#102.